### PR TITLE
Fix branch for docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,4 +20,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/JuliaSIMD/CloseOpenIntervals.jl",
+    devbranch = "main",
 )


### PR DESCRIPTION
Documentation [is not deployed](https://juliasimd.github.io/CloseOpenIntervals.jl/dev) because of [this error](https://github.com/JuliaSIMD/CloseOpenIntervals.jl/runs/3996116177?check_suite_focus=true#step:6:21)